### PR TITLE
Chacha reduce deps

### DIFF
--- a/stream-ciphers/chacha/Cargo.toml
+++ b/stream-ciphers/chacha/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2-chacha"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The CryptoCorrosion Contributors"]
 license = "MIT/Apache-2.0"
 edition = "2018"
@@ -12,7 +12,7 @@ readme = "README.md"
 documentation = "https://docs.rs/c2-chacha"
 
 [dependencies]
-byteorder = "1.3"
+byteorder = { version = "1.3", optional = true }
 lazy_static = { version = "1.2", optional = true }
 simd = { package = "ppv-lite86", version = "0.2.0" }
 stream-cipher = { version = "0.3", optional = true }
@@ -23,7 +23,7 @@ hex-literal = "0.1"
 [features]
 default = ["std", "rustcrypto_api"]
 std = ["lazy_static"]
-rustcrypto_api = ["stream-cipher"]
+rustcrypto_api = ["stream-cipher", "byteorder"]
 
 [badges]
 travis-ci = { repository = "cryptocorrosion/cryptocorrosion" }

--- a/stream-ciphers/chacha/Cargo.toml
+++ b/stream-ciphers/chacha/Cargo.toml
@@ -13,7 +13,6 @@ documentation = "https://docs.rs/c2-chacha"
 
 [dependencies]
 byteorder = "1.3"
-generic-array = "0.13.0"
 lazy_static = { version = "1.2", optional = true }
 simd = { package = "ppv-lite86", version = "0.2.0" }
 stream-cipher = { version = "0.3", optional = true }

--- a/stream-ciphers/chacha/src/guts.rs
+++ b/stream-ciphers/chacha/src/guts.rs
@@ -1,8 +1,6 @@
 #[cfg(feature = "rustcrypto_api")]
 pub use stream_cipher::generic_array;
 
-use byteorder::{ByteOrder, LE};
-
 pub use simd::Machine;
 use simd::{vec128_storage, ArithOps, BitOps32, LaneWords4, MultiLane, StoreBytes, Vec4};
 
@@ -254,17 +252,22 @@ dispatch_light128!(m, Mach, {
     }
 });
 
+fn read_u32le(xs: &[u8]) -> u32 {
+    assert_eq!(xs.len(), 4);
+    u32::from(xs[0]) | (u32::from(xs[1]) << 8) | (u32::from(xs[2]) << 16) | (u32::from(xs[3]) << 24)
+}
+
 dispatch_light128!(m, Mach, {
     fn init_chacha(key: &[u8; 32], nonce: &[u8]) -> ChaCha {
         let ctr_nonce = [
             0,
             if nonce.len() == 12 {
-                LE::read_u32(&nonce[0..4])
+                read_u32le(&nonce[0..4])
             } else {
                 0
             },
-            LE::read_u32(&nonce[nonce.len() - 8..nonce.len() - 4]),
-            LE::read_u32(&nonce[nonce.len() - 4..]),
+            read_u32le(&nonce[nonce.len() - 8..nonce.len() - 4]),
+            read_u32le(&nonce[nonce.len() - 4..]),
         ];
         let key0: Mach::u32x4 = m.read_le(&key[..16]);
         let key1: Mach::u32x4 = m.read_le(&key[16..]);
@@ -287,12 +290,7 @@ dispatch_light128!(m, Mach, {
             d: nonce0.into(),
         };
         let x = refill_narrow_rounds(&mut state, rounds);
-        let ctr_nonce1 = [
-            0,
-            0,
-            LE::read_u32(&nonce[16..20]),
-            LE::read_u32(&nonce[20..24]),
-        ];
+        let ctr_nonce1 = [0, 0, read_u32le(&nonce[16..20]), read_u32le(&nonce[20..24])];
         state.b = x.a;
         state.c = x.d;
         state.d = ctr_nonce1.into();

--- a/stream-ciphers/chacha/src/guts.rs
+++ b/stream-ciphers/chacha/src/guts.rs
@@ -1,12 +1,7 @@
-#[cfg(not(feature = "rustcrypto_api"))]
-pub use generic_array;
 #[cfg(feature = "rustcrypto_api")]
 pub use stream_cipher::generic_array;
 
 use byteorder::{ByteOrder, LE};
-
-use self::generic_array::typenum::{U24, U32};
-use self::generic_array::GenericArray;
 
 pub use simd::Machine;
 use simd::{vec128_storage, ArithOps, BitOps32, LaneWords4, MultiLane, StoreBytes, Vec4};
@@ -64,7 +59,7 @@ pub(crate) fn undiagonalize<V: LaneWords4>(mut x: State<V>) -> State<V> {
 impl ChaCha {
     #[inline(always)]
     pub fn new(key: &[u8; 32], nonce: &[u8]) -> Self {
-        init_chacha(GenericArray::from_slice(key), nonce)
+        init_chacha(key, nonce)
     }
 
     #[inline(always)]
@@ -260,7 +255,7 @@ dispatch_light128!(m, Mach, {
 });
 
 dispatch_light128!(m, Mach, {
-    fn init_chacha(key: &GenericArray<u8, U32>, nonce: &[u8]) -> ChaCha {
+    fn init_chacha(key: &[u8; 32], nonce: &[u8]) -> ChaCha {
         let ctr_nonce = [
             0,
             if nonce.len() == 12 {
@@ -282,11 +277,7 @@ dispatch_light128!(m, Mach, {
 });
 
 dispatch_light128!(m, Mach, {
-    fn init_chacha_x(
-        key: &GenericArray<u8, U32>,
-        nonce: &GenericArray<u8, U24>,
-        rounds: u32,
-    ) -> ChaCha {
+    fn init_chacha_x(key: &[u8; 32], nonce: &[u8; 24], rounds: u32) -> ChaCha {
         let key0: Mach::u32x4 = m.read_le(&key[..16]);
         let key1: Mach::u32x4 = m.read_le(&key[16..]);
         let nonce0: Mach::u32x4 = m.read_le(&nonce[..16]);


### PR DESCRIPTION
Remove some avoidable dependencies when not building stream-cipher impl: generic-array/typenum, byteorder