### PR TITLE
Tweak Chacha and Blake diagonalization to hide latency on b

### DIFF
--- a/hashes/blake/src/lib.rs
+++ b/hashes/blake/src/lib.rs
@@ -74,14 +74,16 @@ fn round64<M: Machine>(
     (a, b, c, d)
 }
 
+
 #[inline(always)]
 fn diagonalize<X4: Words4>((a, b, c, d): (X4, X4, X4, X4)) -> (X4, X4, X4, X4) {
-    (a, b.shuffle3012(), c.shuffle2301(), d.shuffle1230())
+    // Since b has the critical data dependency, avoid rotating b to hide latency.
+    (a.shuffle1230(), b, c.shuffle3012(), d.shuffle2301())
 }
 
 #[inline(always)]
 fn undiagonalize<X4: Words4>((a, b, c, d): (X4, X4, X4, X4)) -> (X4, X4, X4, X4) {
-    (a, b.shuffle1230(), c.shuffle2301(), d.shuffle3012())
+    (a.shuffle3012(), b, c.shuffle1230(), d.shuffle2301())
 }
 
 macro_rules! define_compressor {
@@ -117,8 +119,8 @@ macro_rules! define_compressor {
                     let m1 = mach.vec([m1!(0), m1!(2), m1!(4), m1!(6)]);
                     xs = $round::<M>(xs, m0, m1);
                     // diagonal step
-                    let m0 = mach.vec([m0!(8), m0!(10), m0!(12), m0!(14)]);
-                    let m1 = mach.vec([m1!(8), m1!(10), m1!(12), m1!(14)]);
+                    let m0 = mach.vec([m0!(14), m0!(8), m0!(10), m0!(12)]);
+                    let m1 = mach.vec([m1!(14), m1!(8), m1!(10), m1!(12)]);
                     xs = undiagonalize($round::<M>(diagonalize(xs), m0, m1));
                 }
                 let h: (M::$X4, M::$X4) = (mach.unpack(state.h[0]), mach.unpack(state.h[1]));

--- a/stream-ciphers/chacha/src/guts.rs
+++ b/stream-ciphers/chacha/src/guts.rs
@@ -41,16 +41,18 @@ pub(crate) fn round<V: ArithOps + BitOps32>(mut x: State<V>) -> State<V> {
 
 #[inline(always)]
 pub(crate) fn diagonalize<V: LaneWords4>(mut x: State<V>) -> State<V> {
-    x.b = x.b.shuffle_lane_words3012();
-    x.c = x.c.shuffle_lane_words2301();
-    x.d = x.d.shuffle_lane_words1230();
+    // Since b has the critical data dependency, avoid rotating b to hide latency.
+    x.c = x.c.shuffle_lane_words3012();
+    x.d = x.d.shuffle_lane_words2301();
+    x.a = x.a.shuffle_lane_words1230();
     x
 }
+
 #[inline(always)]
 pub(crate) fn undiagonalize<V: LaneWords4>(mut x: State<V>) -> State<V> {
-    x.b = x.b.shuffle_lane_words1230();
-    x.c = x.c.shuffle_lane_words2301();
-    x.d = x.d.shuffle_lane_words3012();
+    x.c = x.c.shuffle_lane_words1230();
+    x.d = x.d.shuffle_lane_words2301();
+    x.a = x.a.shuffle_lane_words3012();
     x
 }
 


### PR DESCRIPTION
Same change as https://github.com/sneves/blake2-avx2/pull/4

It should improve speed, but I wasn't able to run `cargo bench` on my machine. The test `cargo test` is passing.