### PR TITLE
chore: Update hex-literal to 0.2

### DIFF
--- a/stream-ciphers/chacha/Cargo.toml
+++ b/stream-ciphers/chacha/Cargo.toml
@@ -18,7 +18,7 @@ ppv-lite86 = { package = "ppv-lite86", version = "0.2.1", default-features = fal
 stream-cipher = { version = "0.3", optional = true }
 
 [dev-dependencies]
-hex-literal = "0.1"
+hex-literal = "0.2"
 
 [features]
 default = ["std", "simd", "rustcrypto_api"]


### PR DESCRIPTION
Only change between 0.1 and 0.2 is migration to rust2018.
c2-chacha already requires 2018 edition Rust.