### PR TITLE
Migrate crates to new RustCrypto trait versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ matrix:
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: stable
     - env: TARGET=x86_64-unknown-linux-gnu
-      rust: 1.32.0
+      rust: 1.41.0
 
     # machine-specific tests are skipped based on static feature detection
     - env: TARGET=x86_64-unknown-linux-gnu RUSTFLAGS="-C target-cpu=native"

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,8 @@ matrix:
       rust: nightly
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: stable
+    - env: TARGET=x86_64-unknown-linux-gnu OLDER_MSRV_CRATES=1 DISABLE_TESTS=1
+      rust: 1.32.0
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: 1.41.0
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The main interface to these crates is the RustCrypto traits.
 
 All crates are no-std compatible.
 
-Minimum Rust version: 1.41.0
+Minimum Rust version:
+- algorithm crates (with RustCrypto API): 1.41.0
+- support crates: 1.32.0
 
 [![Build Status](https://travis-ci.org/cryptocorrosion/cryptocorrosion.svg?branch=master)](https://travis-ci.org/cryptocorrosion/cryptocorrosion)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The main interface to these crates is the RustCrypto traits.
 
 All crates are no-std compatible.
 
-Minimum Rust version: 1.32.0
+Minimum Rust version: 1.41.0
 
 [![Build Status](https://travis-ci.org/cryptocorrosion/cryptocorrosion.svg?branch=master)](https://travis-ci.org/cryptocorrosion/cryptocorrosion)
 

--- a/block-ciphers/threefish/Cargo.toml
+++ b/block-ciphers/threefish/Cargo.toml
@@ -9,9 +9,7 @@ repository = "https://github.com/cryptocorrosion/cryptocorrosion"
 keywords = ["crypto", "threefish", "gost", "block-cipher"]
 
 [dependencies]
-generic-array = "0.12"
-byteorder = { version = "1", default-features = false }
-block-cipher-trait = "0.6"
+block-cipher = "0.7"
 
 [dev-dependencies]
 hex-literal = "0.2"

--- a/block-ciphers/threefish/Cargo.toml
+++ b/block-ciphers/threefish/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/cryptocorrosion/cryptocorrosion"
 keywords = ["crypto", "threefish", "gost", "block-cipher"]
 
 [dependencies]
-block-cipher = "0.7"
+block-cipher = "0.8"
 
 [dev-dependencies]
 hex-literal = "0.2"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -27,10 +27,24 @@ portable_only() {
     cross test --target $TARGET --release -p c2-chacha -p ppv-lite86
 }
 
+older_msrv_crates() {
+    cross build --target $TARGET -p ppv-lite86
+    cross build --target $TARGET --release -p ppv-lite86
+
+    if [ ! -z $DISABLE_TESTS ]; then
+        return
+    fi
+
+    cross test --target $TARGET -p ppv-lite86
+    cross test --target $TARGET --release -p ppv-lite86
+}
+
 # we don't run the "test phase" when doing deploys
 if [ -z $TRAVIS_TAG ]; then
     if [ -z $PORTABLE_ONLY ]; then
         main
+    elif [ -z $OLDER_MSRV_CRATES ]; then
+        older_msrv_crates
     else
         portable_only
     fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -41,9 +41,9 @@ older_msrv_crates() {
 
 # we don't run the "test phase" when doing deploys
 if [ -z $TRAVIS_TAG ]; then
-    if [ -n $PORTABLE_ONLY ]; then
+    if [ -n "$PORTABLE_ONLY" ]; then
         portable_only
-    elif [ -n $OLDER_MSRV_CRATES ]; then
+    elif [ -n "$OLDER_MSRV_CRATES" ]; then
         older_msrv_crates
     else
         main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -41,11 +41,11 @@ older_msrv_crates() {
 
 # we don't run the "test phase" when doing deploys
 if [ -z $TRAVIS_TAG ]; then
-    if [ -z $PORTABLE_ONLY ]; then
-        main
-    elif [ -z $OLDER_MSRV_CRATES ]; then
+    if [ -n $PORTABLE_ONLY ]; then
+        portable_only
+    elif [ -n $OLDER_MSRV_CRATES ]; then
         older_msrv_crates
     else
-        portable_only
+        main
     fi
 fi

--- a/hashes/blake/Cargo.toml
+++ b/hashes/blake/Cargo.toml
@@ -9,8 +9,8 @@ keywords = ["crypto", "blake", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-block-buffer = "0.7"
-digest = "0.8"
+block-buffer = "0.9"
+digest = "0.9"
 simd = { package = "ppv-lite86", version = "0.2.6", optional = true }
 
 [features]
@@ -18,7 +18,7 @@ default = ["simd", "std"]
 std = []
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9", features = ["dev"] }
 
 [badges]
 travis-ci = { repository = "cryptocorrosion/cryptocorrosion" }

--- a/hashes/blake/src/lib.rs
+++ b/hashes/blake/src/lib.rs
@@ -256,7 +256,7 @@ macro_rules! define_hasher {
                 buffer.input_block(&msglen, |block| compressor.put_block(block, t));
                 debug_assert_eq!(buffer.position(), 0);
 
-                out.as_mut_slice().copy_from_slice(&compressor.finalize()[..$Bytes::to_usize()]);
+                out.copy_from_slice(&compressor.finalize()[..$Bytes::to_usize()]);
             }
         }
 

--- a/hashes/groestl/Cargo.toml
+++ b/hashes/groestl/Cargo.toml
@@ -11,12 +11,12 @@ repository = "https://github.com/cryptocorrosion/hashes"
 edition = "2018"
 
 [dependencies]
-block-buffer = "0.7"
-digest = "0.8"
+block-buffer = "0.9"
+digest = "0.9"
 lazy_static = { version = "1.2", optional = true }
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9", features = ["dev"] }
 
 [features]
 std = ["lazy_static"]

--- a/hashes/jh/Cargo.toml
+++ b/hashes/jh/Cargo.toml
@@ -11,13 +11,13 @@ repository = "https://github.com/cryptocorrosion/cryptocorrosion"
 edition = "2018"
 
 [dependencies]
-block-buffer = "0.7"
-digest = "0.8"
+block-buffer = "0.9"
+digest = "0.9"
 hex-literal = "0.2"
 simd = { package = "ppv-lite86", version = "0.2.6" }
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9", features = ["dev"] }
 
 [build-dependencies]
 cc = "1.0.3"

--- a/hashes/jh/src/lib.rs
+++ b/hashes/jh/src/lib.rs
@@ -81,7 +81,7 @@ macro_rules! define_hasher {
                     state.input(&last);
                 }
                 let finalized = self.state.finalize();
-                out.as_mut_slice().copy_from_slice(&finalized[(128 - $OutputBytes::to_usize())..]);
+                out.copy_from_slice(&finalized[(128 - $OutputBytes::to_usize())..]);
             }
         }
 

--- a/hashes/skein/Cargo.toml
+++ b/hashes/skein/Cargo.toml
@@ -9,10 +9,9 @@ keywords = ["crypto", "skein", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-block-buffer = "0.7"
-block-padding = "0.1.0"
-digest = "0.8"
+block-buffer = { version = "0.9", features = ["block-padding"] }
+digest = "0.9"
 threefish-cipher = "0.3"
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9", features = ["dev"] }

--- a/stream-ciphers/chacha/Cargo.toml
+++ b/stream-ciphers/chacha/Cargo.toml
@@ -12,9 +12,8 @@ readme = "README.md"
 documentation = "https://docs.rs/c2-chacha"
 
 [dependencies]
-byteorder = { version = "1.3", optional = true }
 ppv-lite86 = { package = "ppv-lite86", version = "0.2.8", default-features = false }
-stream-cipher = { version = "0.3", optional = true }
+stream-cipher = { version = "0.4", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.2"
@@ -22,7 +21,7 @@ hex-literal = "0.2"
 [features]
 default = ["std", "rustcrypto_api"]
 std = ["ppv-lite86/std"]
-rustcrypto_api = ["stream-cipher", "byteorder"]
+rustcrypto_api = ["stream-cipher"]
 no_simd = ["ppv-lite86/no_simd"]
 simd = [] # deprecated
 

--- a/stream-ciphers/chacha/Cargo.toml
+++ b/stream-ciphers/chacha/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/c2-chacha"
 
 [dependencies]
 ppv-lite86 = { package = "ppv-lite86", version = "0.2.8", default-features = false }
-stream-cipher = { version = "0.6", optional = true }
+stream-cipher = { version = "0.7", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.2"

--- a/stream-ciphers/chacha/Cargo.toml
+++ b/stream-ciphers/chacha/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/c2-chacha"
 
 [dependencies]
 ppv-lite86 = { package = "ppv-lite86", version = "0.2.8", default-features = false }
-stream-cipher = { version = "0.4", optional = true }
+stream-cipher = { version = "0.6", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.2"

--- a/stream-ciphers/chacha/src/rustcrypto_impl.rs
+++ b/stream-ciphers/chacha/src/rustcrypto_impl.rs
@@ -1,8 +1,8 @@
-use byteorder::{ByteOrder, LE};
-use core::cmp;
 use crate::guts::generic_array::typenum::{Unsigned, U10, U12, U24, U32, U4, U6, U8};
 use crate::guts::generic_array::{ArrayLength, GenericArray};
 use crate::guts::{ChaCha, Machine, BLOCK, BLOCK64, BUFSZ};
+use core::cmp;
+use core::convert::TryInto;
 pub use stream_cipher;
 use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 
@@ -241,12 +241,12 @@ dispatch_light128!(m, Mach, {
         let ctr_nonce = [
             0,
             if nonce.len() == 12 {
-                LE::read_u32(&nonce[0..4])
+                u32::from_le_bytes(nonce[0..4].try_into().unwrap())
             } else {
                 0
             },
-            LE::read_u32(&nonce[nonce.len() - 8..nonce.len() - 4]),
-            LE::read_u32(&nonce[nonce.len() - 4..]),
+            u32::from_le_bytes(nonce[nonce.len() - 8..nonce.len() - 4].try_into().unwrap()),
+            u32::from_le_bytes(nonce[nonce.len() - 4..].try_into().unwrap()),
         ];
         let key0: Mach::u32x4 = m.read_le(&key[..16]);
         let key1: Mach::u32x4 = m.read_le(&key[16..]);
@@ -276,8 +276,8 @@ dispatch_light128!(m, Mach, {
         let ctr_nonce1 = [
             0,
             0,
-            LE::read_u32(&nonce[16..20]),
-            LE::read_u32(&nonce[20..24]),
+            u32::from_le_bytes(nonce[16..20].try_into().unwrap()),
+            u32::from_le_bytes(nonce[20..24].try_into().unwrap()),
         ];
         state.b = x.a;
         state.c = x.d;


### PR DESCRIPTION
Specific dependency changes:
- `block-buffer 0.7 -> 0.9`
- `block-cipher-trait 0.6 -> block-cipher 0.8`
- `block-padding 0.1 -> 0.2` (now re-exported from `block-buffer`)
- `digest 0.8 -> 0.9`
- `stream-cipher 0.3 -> 0.7`

The MSRV for the algorithm crates is increased to 1.41, matching the MSRV for the new RustCrypto trait versions. `byteorder` has been removed from the RustCrypto APIs and dependencies as part of the MSRV bump; I have similarly replaced it with native APIs here.