### PR TITLE
Migrate to new cipher crate

### DIFF
--- a/block-ciphers/threefish/Cargo.toml
+++ b/block-ciphers/threefish/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/cryptocorrosion/cryptocorrosion"
 keywords = ["crypto", "threefish", "gost", "block-cipher"]
 
 [dependencies]
-block-cipher = "0.8"
+cipher = "0.2"
 
 [dev-dependencies]
 hex-literal = "0.2"

--- a/block-ciphers/threefish/src/lib.rs
+++ b/block-ciphers/threefish/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![allow(non_upper_case_globals)]
-extern crate block_cipher;
+extern crate cipher;
 #[cfg(test)]
 #[macro_use]
 extern crate hex_literal;
@@ -10,9 +10,9 @@ use core::ops::BitXor;
 mod consts;
 use consts::{C240, P_1024, P_256, P_512, R_1024, R_256, R_512};
 
-use block_cipher::generic_array::typenum::{U1, U128, U32, U64};
-use block_cipher::generic_array::GenericArray;
-pub use block_cipher::{BlockCipher, NewBlockCipher};
+use cipher::generic_array::typenum::{U1, U128, U32, U64};
+use cipher::generic_array::GenericArray;
+pub use cipher::{BlockCipher, NewBlockCipher};
 
 fn mix(r: u32, x: (u64, u64)) -> (u64, u64) {
     let y0 = x.0.wrapping_add(x.1);
@@ -209,8 +209,8 @@ mod test {
     //! tests from NIST submission
 
     use super::{Threefish1024, Threefish256, Threefish512};
-    use block_cipher::generic_array::GenericArray;
-    use block_cipher::{BlockCipher, NewBlockCipher};
+    use cipher::generic_array::GenericArray;
+    use cipher::{BlockCipher, NewBlockCipher};
 
     #[test]
     fn test_256() {

--- a/stream-ciphers/chacha/Cargo.toml
+++ b/stream-ciphers/chacha/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/c2-chacha"
 
 [dependencies]
 ppv-lite86 = { package = "ppv-lite86", version = "0.2.8", default-features = false }
-stream-cipher = { version = "0.7", optional = true }
+cipher = { version = "0.2", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.2"
@@ -21,7 +21,7 @@ hex-literal = "0.2"
 [features]
 default = ["std", "rustcrypto_api"]
 std = ["ppv-lite86/std"]
-rustcrypto_api = ["stream-cipher"]
+rustcrypto_api = ["cipher"]
 no_simd = ["ppv-lite86/no_simd"]
 simd = [] # deprecated
 

--- a/stream-ciphers/chacha/src/guts.rs
+++ b/stream-ciphers/chacha/src/guts.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "rustcrypto_api")]
-pub use stream_cipher::generic_array;
+pub use cipher::generic_array;
 
 pub use ppv_lite86::Machine;
 use ppv_lite86::{vec128_storage, ArithOps, BitOps32, LaneWords4, MultiLane, StoreBytes, Vec4};

--- a/stream-ciphers/chacha/src/rustcrypto_impl.rs
+++ b/stream-ciphers/chacha/src/rustcrypto_impl.rs
@@ -3,8 +3,8 @@ use crate::guts::generic_array::{ArrayLength, GenericArray};
 use crate::guts::{ChaCha, Machine, BLOCK, BLOCK64, BUFSZ};
 use core::cmp;
 use core::convert::TryInto;
-pub use stream_cipher;
-use stream_cipher::{
+pub use cipher::stream as stream_cipher;
+use cipher::stream::{
     LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
 };
 


### PR DESCRIPTION
`stream_cipher` is deprecated, `cipher` replaces it. Note that this is a breaking change, as block-cipher and stream-cipher are public dependencies of their respective crates.