### PR TITLE
c2-chacha: add XChaCha8 and XChaCha12

### DIFF
--- a/stream-ciphers/chacha/src/lib.rs
+++ b/stream-ciphers/chacha/src/lib.rs
@@ -42,4 +42,4 @@ pub mod guts;
 #[cfg(feature = "rustcrypto_api")]
 mod rustcrypto_impl;
 #[cfg(feature = "rustcrypto_api")]
-pub use self::rustcrypto_impl::{stream_cipher, ChaCha12, ChaCha20, ChaCha8, Ietf, XChaCha20};
+pub use self::rustcrypto_impl::{stream_cipher, Ietf, ChaCha8, ChaCha12, ChaCha20, XChaCha8, XChaCha12, XChaCha20};

--- a/stream-ciphers/chacha/src/rustcrypto_impl.rs
+++ b/stream-ciphers/chacha/src/rustcrypto_impl.rs
@@ -292,12 +292,18 @@ dispatch_light128!(m, Mach, {
 
 /// IETF RFC 7539 ChaCha. Unsuitable for messages longer than 256 GiB.
 pub type Ietf = ChaChaAny<U12, U10, O>;
-/// ChaCha20, as used in several standards; from Bernstein's original publication.
-pub type ChaCha20 = ChaChaAny<U8, U10, O>;
-/// Similar to ChaCha20, but with fewer rounds for higher performance.
-pub type ChaCha12 = ChaChaAny<U8, U6, O>;
 /// Similar to ChaCha20, but with fewer rounds for higher performance.
 pub type ChaCha8 = ChaChaAny<U8, U4, O>;
+/// Similar to ChaCha20, but with fewer rounds for higher performance.
+pub type ChaCha12 = ChaChaAny<U8, U6, O>;
+/// ChaCha20, as used in several standards; from Bernstein's original publication.
+pub type ChaCha20 = ChaChaAny<U8, U10, O>;
+/// Constructed analogously to XChaCha20, but with fewer rounds for higher performance;
+/// mixes during initialization to support both a long nonce and a full-length (64-bit) block counter.
+pub type XChaCha8 = ChaChaAny<U24, U4, X>;
+/// Constructed analogously to XChaCha20, but with fewer rounds for higher performance;
+/// mixes during initialization to support both a long nonce and a full-length (64-bit) block counter.
+pub type XChaCha12 = ChaChaAny<U24, U6, X>;
 /// Constructed analogously to XSalsa20; mixes during initialization to support both a long nonce
 /// and a full-length (64-bit) block counter.
 pub type XChaCha20 = ChaChaAny<U24, U10, X>;


### PR DESCRIPTION
I wanted to use a lower round version of XChaCha from this crate but the `ChaChaAny` struct is not publicly available.
Here is a patch to add two "obvious" versions of XChaCha.

The rationale mostly comes from:  
- ["Too Much Crypto" by Jean-Philippe Aumasson](https://eprint.iacr.org/2019/1492.pdf)
- The 7 round design of [Blake3](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf)
- The 12 round design of [KangarooTwelve](https://keccak.team/kangarootwelve.html)
  - Slide "Status of Keccak & KangarooTwelve cryptanalysis" (page 33) of those [slides](https://keccak.team/files/K12atACNS.pdf)
  - The rationale in the [spec](https://keccak.team/files/KangarooTwelve.pdf)