### PR TITLE
ppv-lite86: fix missed #inlines

### DIFF
--- a/utils-simd/ppv-lite86/Cargo.toml
+++ b/utils-simd/ppv-lite86/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.11"
 authors = ["The CryptoCorrosion Contributors"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/utils-simd/ppv-lite86/src/generic.rs
+++ b/utils-simd/ppv-lite86/src/generic.rs
@@ -11,38 +11,38 @@ pub union vec128_storage {
     q: [u64; 2],
 }
 impl From<[u32; 4]> for vec128_storage {
-    #[inline]
+    #[inline(always)]
     fn from(d: [u32; 4]) -> Self {
         Self { d }
     }
 }
 impl From<vec128_storage> for [u32; 4] {
-    #[inline]
+    #[inline(always)]
     fn from(d: vec128_storage) -> Self {
         unsafe { d.d }
     }
 }
 impl From<[u64; 2]> for vec128_storage {
-    #[inline]
+    #[inline(always)]
     fn from(q: [u64; 2]) -> Self {
         Self { q }
     }
 }
 impl From<vec128_storage> for [u64; 2] {
-    #[inline]
+    #[inline(always)]
     fn from(q: vec128_storage) -> Self {
         unsafe { q.q }
     }
 }
 impl Default for vec128_storage {
-    #[inline]
+    #[inline(always)]
     fn default() -> Self {
         Self { q: [0, 0] }
     }
 }
 impl Eq for vec128_storage {}
 impl PartialEq<vec128_storage> for vec128_storage {
-    #[inline]
+    #[inline(always)]
     fn eq(&self, rhs: &Self) -> bool {
         unsafe { self.q == rhs.q }
     }
@@ -62,7 +62,7 @@ impl vec256_storage {
     }
 }
 impl From<vec256_storage> for [u64; 4] {
-    #[inline]
+    #[inline(always)]
     fn from(q: vec256_storage) -> Self {
         let [a, b]: [u64; 2] = q.v128[0].into();
         let [c, d]: [u64; 2] = q.v128[1].into();
@@ -84,6 +84,7 @@ impl vec512_storage {
     }
 }
 
+#[inline(always)]
 fn dmap<T, F>(t: T, f: F) -> T
 where
     T: Store<vec128_storage> + Into<vec128_storage>,
@@ -117,6 +118,7 @@ where
     unsafe { T::unpack(d) }
 }
 
+#[inline(always)]
 fn qmap<T, F>(t: T, f: F) -> T
 where
     T: Store<vec128_storage> + Into<vec128_storage>,
@@ -130,6 +132,7 @@ where
     unsafe { T::unpack(q) }
 }
 
+#[inline(always)]
 fn qmap2<T, F>(a: T, b: T, f: F) -> T
 where
     T: Store<vec128_storage> + Into<vec128_storage>,
@@ -145,14 +148,17 @@ where
     unsafe { T::unpack(q) }
 }
 
+#[inline(always)]
 fn o_of_q(q: [u64; 2]) -> u128 {
     u128::from(q[0]) | (u128::from(q[1]) << 64)
 }
 
+#[inline(always)]
 fn q_of_o(o: u128) -> [u64; 2] {
     [o as u64, (o >> 64) as u64]
 }
 
+#[inline(always)]
 fn omap<T, F>(a: T, f: F) -> T
 where
     T: Store<vec128_storage> + Into<vec128_storage>,
@@ -164,6 +170,7 @@ where
     unsafe { T::unpack(o) }
 }
 
+#[inline(always)]
 fn omap2<T, F>(a: T, b: T, f: F) -> T
 where
     T: Store<vec128_storage> + Into<vec128_storage>,
@@ -247,39 +254,39 @@ macro_rules! impl_bitops {
         }
 
         impl Swap64 for $vec {
-            #[inline]
+            #[inline(always)]
             fn swap1(self) -> Self {
                 qmap(self, |x| {
                     ((x & 0x5555555555555555) << 1) | ((x & 0xaaaaaaaaaaaaaaaa) >> 1)
                 })
             }
-            #[inline]
+            #[inline(always)]
             fn swap2(self) -> Self {
                 qmap(self, |x| {
                     ((x & 0x3333333333333333) << 2) | ((x & 0xcccccccccccccccc) >> 2)
                 })
             }
-            #[inline]
+            #[inline(always)]
             fn swap4(self) -> Self {
                 qmap(self, |x| {
                     ((x & 0x0f0f0f0f0f0f0f0f) << 4) | ((x & 0xf0f0f0f0f0f0f0f0) >> 4)
                 })
             }
-            #[inline]
+            #[inline(always)]
             fn swap8(self) -> Self {
                 qmap(self, |x| {
                     ((x & 0x00ff00ff00ff00ff) << 8) | ((x & 0xff00ff00ff00ff00) >> 8)
                 })
             }
-            #[inline]
+            #[inline(always)]
             fn swap16(self) -> Self {
                 dmap(self, |x| x.rotate_left(16))
             }
-            #[inline]
+            #[inline(always)]
             fn swap32(self) -> Self {
                 qmap(self, |x| x.rotate_left(32))
             }
-            #[inline]
+            #[inline(always)]
             fn swap64(self) -> Self {
                 omap(self, |x| (x << 64) | (x >> 64))
             }
@@ -291,82 +298,83 @@ impl_bitops!(u64x2_generic);
 impl_bitops!(u128x1_generic);
 
 impl RotateEachWord32 for u32x4_generic {
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right7(self) -> Self {
         dmap(self, |x| x.rotate_right(7))
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right8(self) -> Self {
         dmap(self, |x| x.rotate_right(8))
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right11(self) -> Self {
         dmap(self, |x| x.rotate_right(11))
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right12(self) -> Self {
         dmap(self, |x| x.rotate_right(12))
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right16(self) -> Self {
         dmap(self, |x| x.rotate_right(16))
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right20(self) -> Self {
         dmap(self, |x| x.rotate_right(20))
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right24(self) -> Self {
         dmap(self, |x| x.rotate_right(24))
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right25(self) -> Self {
         dmap(self, |x| x.rotate_right(25))
     }
 }
 
 impl RotateEachWord32 for u64x2_generic {
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right7(self) -> Self {
         qmap(self, |x| x.rotate_right(7))
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right8(self) -> Self {
         qmap(self, |x| x.rotate_right(8))
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right11(self) -> Self {
         qmap(self, |x| x.rotate_right(11))
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right12(self) -> Self {
         qmap(self, |x| x.rotate_right(12))
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right16(self) -> Self {
         qmap(self, |x| x.rotate_right(16))
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right20(self) -> Self {
         qmap(self, |x| x.rotate_right(20))
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right24(self) -> Self {
         qmap(self, |x| x.rotate_right(24))
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right25(self) -> Self {
         qmap(self, |x| x.rotate_right(25))
     }
 }
 impl RotateEachWord64 for u64x2_generic {
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right32(self) -> Self {
         qmap(self, |x| x.rotate_right(32))
     }
 }
 
 // workaround for koute/cargo-web#52 (u128::rotate_* broken with cargo web)
+#[inline(always)]
 fn rotate_u128_right(x: u128, i: u32) -> u128 {
     (x >> i) | (x << (128 - i))
 }
@@ -377,41 +385,41 @@ fn test_rotate_u128() {
 }
 
 impl RotateEachWord32 for u128x1_generic {
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right7(self) -> Self {
         Self([rotate_u128_right(self.0[0], 7)])
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right8(self) -> Self {
         Self([rotate_u128_right(self.0[0], 8)])
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right11(self) -> Self {
         Self([rotate_u128_right(self.0[0], 11)])
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right12(self) -> Self {
         Self([rotate_u128_right(self.0[0], 12)])
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right16(self) -> Self {
         Self([rotate_u128_right(self.0[0], 16)])
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right20(self) -> Self {
         Self([rotate_u128_right(self.0[0], 20)])
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right24(self) -> Self {
         Self([rotate_u128_right(self.0[0], 24)])
     }
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right25(self) -> Self {
         Self([rotate_u128_right(self.0[0], 25)])
     }
 }
 impl RotateEachWord64 for u128x1_generic {
-    #[inline]
+    #[inline(always)]
     fn rotate_each_word_right32(self) -> Self {
         Self([rotate_u128_right(self.0[0], 32)])
     }
@@ -430,7 +438,7 @@ impl Machine for GenericMachine {
     type u32x4x4 = u32x4x4_generic;
     type u64x2x4 = u64x2x4_generic;
     type u128x4 = u128x4_generic;
-    #[inline]
+    #[inline(always)]
     unsafe fn instance() -> Self {
         Self
     }
@@ -747,7 +755,7 @@ impl u128x4<GenericMachine> for u128x4_generic {}
 #[macro_export]
 macro_rules! dispatch {
     ($mach:ident, $MTy:ident, { $([$pub:tt$(($krate:tt))*])* fn $name:ident($($arg:ident: $argty:ty),* $(,)*) -> $ret:ty $body:block }) => {
-        #[inline]
+        #[inline(always)]
         $($pub$(($krate))*)* fn $name($($arg: $argty),*) -> $ret {
             let $mach = unsafe { $crate::generic::GenericMachine::instance() };
             #[inline(always)]
@@ -764,7 +772,7 @@ macro_rules! dispatch {
 #[macro_export]
 macro_rules! dispatch_light128 {
     ($mach:ident, $MTy:ident, { $([$pub:tt$(($krate:tt))*])* fn $name:ident($($arg:ident: $argty:ty),* $(,)*) -> $ret:ty $body:block }) => {
-        #[inline]
+        #[inline(always)]
         $($pub$(($krate))*)* fn $name($($arg: $argty),*) -> $ret {
             let $mach = unsafe { $crate::generic::GenericMachine::instance() };
             #[inline(always)]
@@ -781,7 +789,7 @@ macro_rules! dispatch_light128 {
 #[macro_export]
 macro_rules! dispatch_light256 {
     ($mach:ident, $MTy:ident, { $([$pub:tt$(($krate:tt))*])* fn $name:ident($($arg:ident: $argty:ty),* $(,)*) -> $ret:ty $body:block }) => {
-        #[inline]
+        #[inline(always)]
         $($pub$(($krate))*)* fn $name($($arg: $argty),*) -> $ret {
             let $mach = unsafe { $crate::generic::GenericMachine::instance() };
             #[inline(always)]
@@ -798,7 +806,7 @@ macro_rules! dispatch_light256 {
 #[macro_export]
 macro_rules! dispatch_light512 {
     ($mach:ident, $MTy:ident, { $([$pub:tt$(($krate:tt))*])* fn $name:ident($($arg:ident: $argty:ty),* $(,)*) -> $ret:ty $body:block }) => {
-        #[inline]
+        #[inline(always)]
         $($pub$(($krate))*)* fn $name($($arg: $argty),*) -> $ret {
             let $mach = unsafe { $crate::generic::GenericMachine::instance() };
             #[inline(always)]

--- a/utils-simd/ppv-lite86/src/x86_64/mod.rs
+++ b/utils-simd/ppv-lite86/src/x86_64/mod.rs
@@ -167,9 +167,11 @@ impl Default for vec256_storage {
     }
 }
 impl vec256_storage {
+    #[inline(always)]
     pub fn new128(xs: [vec128_storage; 2]) -> Self {
         Self { sse2: xs }
     }
+    #[inline(always)]
     pub fn split128(self) -> [vec128_storage; 2] {
         unsafe { self.sse2 }
     }
@@ -200,9 +202,11 @@ impl Default for vec512_storage {
     }
 }
 impl vec512_storage {
+    #[inline(always)]
     pub fn new128(xs: [vec128_storage; 4]) -> Self {
         Self { sse2: xs }
     }
+    #[inline(always)]
     pub fn split128(self) -> [vec128_storage; 4] {
         unsafe { self.sse2 }
     }


### PR DESCRIPTION
This may improve performance substantially for code that uses affected functions.