### PR TITLE
ppv-lite86: impl transpose4 and to_scalars

### DIFF
--- a/utils-simd/ppv-lite86/src/soft.rs
+++ b/utils-simd/ppv-lite86/src/soft.rs
@@ -310,6 +310,17 @@ impl<W: Copy> Vec4<W> for x4<W> {
         self
     }
 }
+impl<W: Copy> Vec4Ext<W> for x4<W> {
+    #[inline(always)]
+    fn transpose4(a: Self, b: Self, c: Self, d: Self) -> (Self, Self, Self, Self) where Self: Sized {
+        (
+            x4([a.0[0], b.0[0], c.0[0], d.0[0]]),
+            x4([a.0[1], b.0[1], c.0[1], d.0[1]]),
+            x4([a.0[2], b.0[2], c.0[2], d.0[2]]),
+            x4([a.0[3], b.0[3], c.0[3], d.0[3]])
+        )
+    }
+}
 impl<W: Copy + Store<vec128_storage>> Store<vec512_storage> for x4<W> {
     #[inline(always)]
     unsafe fn unpack(p: vec512_storage) -> Self {

--- a/utils-simd/ppv-lite86/src/types.rs
+++ b/utils-simd/ppv-lite86/src/types.rs
@@ -71,6 +71,15 @@ pub trait Vec4<W> {
     fn extract(self, i: u32) -> W;
     fn insert(self, w: W, i: u32) -> Self;
 }
+/// Vec4 functions which may not be implemented yet for all Vec4 types.
+/// NOTE: functions in this trait may be moved to Vec4 in any patch release. To avoid breakage,
+/// import Vec4Ext only together with Vec4, and don't qualify its methods.
+pub trait Vec4Ext<W> {
+    fn transpose4(a: Self, b: Self, c: Self, d: Self) -> (Self, Self, Self, Self) where Self: Sized;
+}
+pub trait Vector<T> {
+    fn to_scalars(self) -> T;
+}
 
 // TODO: multiples of 4 should inherit this
 /// A vector composed of four words; depending on their size, operations may cross lanes.
@@ -169,6 +178,8 @@ pub trait u32x4x4<M: Machine>:
     BitOps32
     + Store<vec512_storage>
     + Vec4<M::u32x4>
+    + Vec4Ext<M::u32x4>
+    + Vector<[u32; 16]>
     + MultiLane<[M::u32x4; 4]>
     + ArithOps
     + LaneWords4


### PR DESCRIPTION
Only for u32x4x4 types for now, in principle the transpose family and
to_scalars could be implemented for almost everything.