### PR TITLE
ppv-lite86: release 0.2.13

### DIFF
--- a/utils-simd/ppv-lite86/Cargo.toml
+++ b/utils-simd/ppv-lite86/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ppv-lite86"
-version = "0.2.12"
+version = "0.2.13"
 authors = ["The CryptoCorrosion Contributors"]
 edition = "2018"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
- [x] test with 1.32.0-x86_64-unknown-linux-gnu
- [x] test with stable-x86_64-unknown-linux-gnu
- [x] test with nightly-x86_64-unknown-linux-gnu
- [x] test with stable-x86_64-unknown-linux-gnu, no-default-features (no std)
- [x] test with 1.32.0-x86_64-unknown-linux-gnu, features = no_simd
- [x] test with stable-x86_64-unknown-linux-gnu, features = no_simd