### PR TITLE
Use generic implementation on x86-without-simd

### DIFF
--- a/utils-simd/ppv-lite86/src/lib.rs
+++ b/utils-simd/ppv-lite86/src/lib.rs
@@ -9,14 +9,14 @@ mod soft;
 mod types;
 pub use self::types::*;
 
-#[cfg(all(target_arch = "x86_64", not(feature = "no_simd"), not(miri)))]
+#[cfg(all(target_arch = "x86_64", target_feature = "sse2", not(feature = "no_simd"), not(miri)))]
 pub mod x86_64;
-#[cfg(all(target_arch = "x86_64", not(feature = "no_simd"), not(miri)))]
+#[cfg(all(target_arch = "x86_64", target_feature = "sse2", not(feature = "no_simd"), not(miri)))]
 use self::x86_64 as arch;
 
-#[cfg(any(feature = "no_simd", miri, not(target_arch = "x86_64")))]
+#[cfg(any(feature = "no_simd", miri, not(target_arch = "x86_64"), all(target_arch = "x86_64", not(target_feature = "sse2"))))]
 pub mod generic;
-#[cfg(any(feature = "no_simd", miri, not(target_arch = "x86_64")))]
+#[cfg(any(feature = "no_simd", miri, not(target_arch = "x86_64"), all(target_arch = "x86_64", not(target_feature = "sse2"))))]
 use self::generic as arch;
 
 pub use self::arch::{vec128_storage, vec256_storage, vec512_storage};


### PR DESCRIPTION
When compiled for non-SSE2 x86-64 platforms, use the emulated SIMD primitives.