### PR TITLE
Added Zeroize Support for ppv_lite86

### DIFF
--- a/utils-simd/ppv-lite86/CHANGELOG.md
+++ b/utils-simd/ppv-lite86/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-09-21
+
+### Added
+- Introduced `zeroize_support` feature for securely zeroing out sensitive data in memory.
+  - Implemented `Zeroize` trait for relevant types in the library to enable secure zeroing when the feature is enabled.
+  - This feature can be enabled via `ppv_lite86 = { version = "0.3", features = ["zeroize_support"] }` in your `Cargo.toml`.
+
 ## [0.2.16]
 ### Added
 - add [u64; 4] conversion for generic vec256, to support BLAKE on non-x86.

--- a/utils-simd/ppv-lite86/CHANGELOG.md
+++ b/utils-simd/ppv-lite86/CHANGELOG.md
@@ -4,13 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2023-09-21
-
-### Added
-- Introduced `zeroize_support` feature for securely zeroing out sensitive data in memory.
-  - Implemented `Zeroize` trait for relevant types in the library to enable secure zeroing when the feature is enabled.
-  - This feature can be enabled via `ppv_lite86 = { version = "0.3", features = ["zeroize_support"] }` in your `Cargo.toml`.
-
 ## [0.2.16]
 ### Added
 - add [u64; 4] conversion for generic vec256, to support BLAKE on non-x86.

--- a/utils-simd/ppv-lite86/Cargo.toml
+++ b/utils-simd/ppv-lite86/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ppv-lite86"
-version = "0.3.0"
+version = "0.2.17"
 authors = ["The CryptoCorrosion Contributors"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/utils-simd/ppv-lite86/Cargo.toml
+++ b/utils-simd/ppv-lite86/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["crypto", "simd", "x86"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-zeroize = { version = "1.6.0", optional = true }
+zeroize = { version = "1.6.0", optional = true, features = ["zeroize_derive"] }
 
 [badges]
 travis-ci = { repository = "cryptocorrosion/cryptocorrosion" }

--- a/utils-simd/ppv-lite86/Cargo.toml
+++ b/utils-simd/ppv-lite86/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.3.0"
 authors = ["The CryptoCorrosion Contributors"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -10,6 +10,7 @@ keywords = ["crypto", "simd", "x86"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
+zeroize = { version = "1.6.0", optional = true }
 
 [badges]
 travis-ci = { repository = "cryptocorrosion/cryptocorrosion" }
@@ -19,3 +20,4 @@ default = ["std"]
 std = []
 simd = [] # deprecated
 no_simd = []
+zeroize_support = ["zeroize"]

--- a/utils-simd/ppv-lite86/src/generic.rs
+++ b/utils-simd/ppv-lite86/src/generic.rs
@@ -4,12 +4,19 @@ use crate::soft::{x2, x4};
 use crate::types::*;
 use core::ops::*;
 
+#[cfg(feature = "zeroize_support")] use zeroize::Zeroize;
+
 #[repr(C)]
 #[derive(Clone, Copy)]
+#[cfg_attr(
+    feature = "zeroize_support",
+    derive(Zeroize),
+)]
 pub union vec128_storage {
     d: [u32; 4],
     q: [u64; 2],
 }
+#[cfg(feature = "zeroize_support")]
 impl From<[u32; 4]> for vec128_storage {
     #[inline(always)]
     fn from(d: [u32; 4]) -> Self {
@@ -48,6 +55,10 @@ impl PartialEq<vec128_storage> for vec128_storage {
     }
 }
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(
+    feature = "zeroize_support",
+    derive(Zeroize)
+)]
 pub struct vec256_storage {
     v128: [vec128_storage; 2],
 }
@@ -78,6 +89,10 @@ impl From<[u64; 4]> for vec256_storage {
     }
 }
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(
+    feature = "zeroize_support",
+    derive(Zeroize)
+)]
 pub struct vec512_storage {
     v128: [vec128_storage; 4],
 }
@@ -861,5 +876,11 @@ mod test {
 
         let y = m.vec(ys);
         assert_eq!(x, y);
+    }
+
+    #[test]
+    #[cfg(feature = "zeroize")]
+    fn test_zeroize_vec128_storage_generic() {
+        
     }
 }

--- a/utils-simd/ppv-lite86/src/generic.rs
+++ b/utils-simd/ppv-lite86/src/generic.rs
@@ -8,15 +8,18 @@ use core::ops::*;
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-#[cfg_attr(
-    feature = "zeroize_support",
-    derive(Zeroize),
-)]
 pub union vec128_storage {
     d: [u32; 4],
     q: [u64; 2],
 }
 #[cfg(feature = "zeroize_support")]
+impl Zeroize for vec128_storage {
+    fn zeroize(&mut self) {
+        unsafe {
+            self.d.zeroize();
+        }
+    }
+}
 impl From<[u32; 4]> for vec128_storage {
     #[inline(always)]
     fn from(d: [u32; 4]) -> Self {
@@ -881,6 +884,15 @@ mod test {
     #[test]
     #[cfg(feature = "zeroize")]
     fn test_zeroize_vec128_storage_generic() {
-        
+        let xs = [0x0405_0607, 0x0001_0203, 0x0302_0100, 0x0706_0504];
+
+        let mut vec = vec128_storage::from(xs);
+
+        vec.zeroize();
+
+        unsafe {
+            assert_eq!(vec.d, [0u32; 4]);
+            assert_eq!(vec.q, [0u64; 2]);
+        }
     }
 }

--- a/utils-simd/ppv-lite86/src/generic.rs
+++ b/utils-simd/ppv-lite86/src/generic.rs
@@ -881,8 +881,16 @@ mod test {
         assert_eq!(x, y);
     }
 
+    #[cfg(feature = "zeroize_support")]
+    fn zeroize_v128_assertions(v: &vec128_storage) {
+        unsafe {
+            assert_eq!(v.d, [0u32; 4]);
+            assert_eq!(v.q, [0u64; 2]);
+        }
+    }
+
     #[test]
-    #[cfg(feature = "zeroize")]
+    #[cfg(feature = "zeroize_support")]
     fn test_zeroize_vec128_storage_generic() {
         let xs = [0x0405_0607, 0x0001_0203, 0x0302_0100, 0x0706_0504];
 
@@ -890,9 +898,44 @@ mod test {
 
         vec.zeroize();
 
-        unsafe {
-            assert_eq!(vec.d, [0u32; 4]);
-            assert_eq!(vec.q, [0u64; 2]);
+        zeroize_v128_assertions(&vec);
+    }
+
+    #[test]
+    #[cfg(feature = "zeroize_support")]
+    fn test_zeroize_vec256_storage_generic() {
+        let xs = [0x0405_0607, 0x0001_0203, 0x0302_0100, 0x0706_0504];
+
+        let mut vec = vec256_storage::from(xs);
+
+        vec.zeroize();
+
+        for x in vec.v128.iter() {
+            zeroize_v128_assertions(x);
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "zeroize_support")]
+    fn test_zeroize_vec512_storage_generic() {
+        let xs1 = [0x0405_0607, 0x0001_0203, 0x0302_0100, 0x0706_0504];
+        let xs2 = [0x0405_0607, 0x0001_0203, 0x0302_0100, 0x0706_0504];
+        let xs3 = [0x0405_0607, 0x0001_0203, 0x0302_0100, 0x0706_0504];
+        let xs4 = [0x0405_0607, 0x0001_0203, 0x0302_0100, 0x0706_0504];
+
+        let v1 = vec128_storage::from(xs1);
+        let v2 = vec128_storage::from(xs2);
+        let v3 = vec128_storage::from(xs3);
+        let v4 = vec128_storage::from(xs4);
+
+        let v: [vec128_storage; 4] = [v1, v2, v3, v4];
+
+        let mut vec = vec512_storage::new128(v);
+
+        vec.zeroize();
+
+        for x in vec.v128.iter() {
+            zeroize_v128_assertions(x);
         }
     }
 }

--- a/utils-simd/ppv-lite86/src/x86_64/mod.rs
+++ b/utils-simd/ppv-lite86/src/x86_64/mod.rs
@@ -467,12 +467,14 @@ macro_rules! dispatch_light256 {
 #[cfg(test)]
 mod test {
     use super::*;
+    #[cfg(feature = "zeroize_support")]
     use core::mem::transmute;
 
     #[cfg(all(feature = "zeroize_support", any(target_arch = "x86", target_arch = "x86_64")))]
     fn vec128_storage_zeroize_assertions(m: &vec128_storage) {
         unsafe {
             assert_eq!(m.u32x4, [0u32; 4]);
+            // this might be redundant... but as long as the tests pass it should be okay
             assert_eq!(m.u64x2, [0u64; 2]);
             assert_eq!(m.u128x1, [0u128; 1]);
             let arr: [u32; 4] = transmute(*m);

--- a/utils-simd/ppv-lite86/src/x86_64/mod.rs
+++ b/utils-simd/ppv-lite86/src/x86_64/mod.rs
@@ -461,7 +461,6 @@ mod test {
         let mut m = vec128_storage::from(xs);
 
         m.zeroize();
-        /// accessing union field is unsafe
         unsafe {
             assert_eq!(m.u32x4, [0u32; 4]);
             assert_eq!(m.u64x2, [0u64; 2]);

--- a/utils-simd/ppv-lite86/src/x86_64/mod.rs
+++ b/utils-simd/ppv-lite86/src/x86_64/mod.rs
@@ -166,6 +166,14 @@ pub union vec256_storage {
     sse2: [vec128_storage; 2],
     avx: __m256i,
 }
+#[cfg(feature = "zeroize_support")]
+impl Zeroize for vec256_storage {
+    fn zeroize(&mut self) {
+        unsafe {
+            self.sse2.zeroize();
+        }
+    }
+}
 impl From<[u64; 4]> for vec256_storage {
     #[inline(always)]
     fn from(u64x4: [u64; 4]) -> Self {
@@ -204,6 +212,14 @@ pub union vec512_storage {
     u128x4: [u128; 4],
     sse2: [vec128_storage; 4],
     avx: [vec256_storage; 2],
+}
+#[cfg(feature = "zeroize_support")]
+impl Zeroize for vec512_storage {
+    fn zeroize(&mut self) {
+        unsafe {
+            self.sse2.zeroize();
+        }
+    }
 }
 impl Default for vec512_storage {
     #[inline(always)]
@@ -453,6 +469,47 @@ mod test {
     use super::*;
     use core::mem::transmute;
 
+    #[cfg(all(feature = "zeroize_support", any(target_arch = "x86", target_arch = "x86_64")))]
+    fn vec128_storage_zeroize_assertions(m: &vec128_storage) {
+        unsafe {
+            assert_eq!(m.u32x4, [0u32; 4]);
+            assert_eq!(m.u64x2, [0u64; 2]);
+            assert_eq!(m.u128x1, [0u128; 1]);
+            let arr: [u32; 4] = transmute(*m);
+            assert_eq!(arr, [0u32; 4]);
+        }
+    }
+
+    #[cfg(all(feature = "zeroize_support", any(target_arch = "x86", target_arch = "x86_64")))]
+    fn vec256_storage_zeroize_assertions(m: &vec256_storage) {
+        unsafe {
+            assert_eq!(m.u32x8, [0u32; 8]);
+            assert_eq!(m.u64x4, [0u64; 4]);
+            assert_eq!(m.u128x2, [0u128; 2]);
+            let sse2: [vec128_storage; 2] = m.sse2;
+            for s in sse2.iter() {
+                vec128_storage_zeroize_assertions(s);
+            }
+            let arr: [u32; 8] = transmute(*m);
+            assert_eq!(arr, [0u32; 8]);
+        }
+    }
+
+    #[cfg(all(feature = "zeroize_support", any(target_arch = "x86", target_arch = "x86_64")))]
+    fn vec512_storage_zeroize_assertions(m: &vec512_storage) {
+        unsafe {
+            assert_eq!(m.u32x16, [0u32; 16]);
+            assert_eq!(m.u64x8, [0u64; 8]);
+            assert_eq!(m.u128x4, [0u128; 4]);
+            for s in m.sse2.iter() {
+                vec128_storage_zeroize_assertions(s);
+            }
+            for s in m.avx.iter() {
+                vec256_storage_zeroize_assertions(s);
+            }
+        }
+    }
+
     #[test]
     #[cfg(all(feature = "zeroize_support", any(target_arch = "x86", target_arch = "x86_64")))]
     fn test_zeroize_vec128_storage() {
@@ -461,12 +518,35 @@ mod test {
         let mut m = vec128_storage::from(xs);
 
         m.zeroize();
-        unsafe {
-            assert_eq!(m.u32x4, [0u32; 4]);
-            assert_eq!(m.u64x2, [0u64; 2]);
-            assert_eq!(m.u128x1, [0u128; 1]);
-            let arr: [u32; 4] = transmute(m);
-            assert_eq!(arr, [0u32; 4]);
-        }
+        vec128_storage_zeroize_assertions(&m);
+    }
+
+    #[test]
+    #[cfg(all(feature = "zeroize_support", any(target_arch = "x86", target_arch = "x86_64")))]
+    fn test_zeroize_vec256_storage() {
+        let xs: [u64; 4] = [0x0001_0203_0405_0607, 0x0302_0100_0f0e_0d0c, 0x1001_4203_0425_0607, 0x6302_0100_3f0e_0d0c];
+        let mut m = vec256_storage::from(xs);
+
+        m.zeroize();
+        vec256_storage_zeroize_assertions(&m);
+    }
+
+    #[test]
+    #[cfg(all(feature = "zeroize_support", any(target_arch = "x86", target_arch = "x86_64")))]
+    fn test_zeroize_vec512_storage() {
+        let xs1 = [0x0f0e_0d0c, 0x0b0a_0908, 0x0706_0504, 0x0302_0100];
+        let xs2 = [0x3f3e_2d0c, 0x1b0a_0328, 0x5706_0554, 0x0312_0104];
+        let xs3 = [0x0f0b_0d2c, 0x0b0b_0902, 0x2706_0534, 0x2306_0121];
+        let xs4 = [0x3f3e_2d1c, 0x1bba_1328, 0x5726_0524, 0x5212_0144];
+        let xs: [vec128_storage; 4] = [
+            vec128_storage::from(xs1),
+            vec128_storage::from(xs2),
+            vec128_storage::from(xs3),
+            vec128_storage::from(xs4)
+        ];
+        let mut m = vec512_storage::new128(xs);
+        
+        m.zeroize();
+        vec512_storage_zeroize_assertions(&m);
     }
 }


### PR DESCRIPTION
# Intro
Hey, folks. I've been working on some cryptography that is using the `rand/rand_chacha` crate, and I noticed that the RNG I was going to use couldn't be zeroized due to its dependencies not supporting it (`ppv-lite86`). For me, this is important because my code will be running on a cloud provider's servers, and while they have some security measures under the hood... I would rather not chance it. I saw an open issue about zeroize support in `rand_chacha`, as well as in `ethereum/kzg-ceremony-sequencer`. They mention the idea of an upstream contribution, so here is my attempt at one.

# Previously reported issues:
https://github.com/rust-random/rand/issues/934
https://github.com/ethereum/kzg-ceremony-sequencer/issues/165

# Changes
I've added a feature, `zeroize_support`, that allows the following types to be zeroized:
* `vec128_storage` in both `src/generic.rs` and `src/x86_64/mod.rs`
* `vec256_storage` in both `src/generic.rs` and `src/x86_64/mod.rs`
* `vec512_storage` in both `src/generic.rs` and `src/x86_64/mod.rs`

For the RNG that I'm using, the only one that requires `.zeroize()` is `vec128_storage`, but I went ahead and added it for all of those just in case anyone might need it.

# Testing
The zeroize_support feature has been successfully tested on x86_64 on a 13th-generation Intel Core CPU and aarch64 Apple M1 chip.

## x86 test results
```
/cryptocorrosion/utils-simd/ppv-lite86$ cargo test --release --features zeroize_support
   Compiling ppv-lite86 v0.2.17 (/cryptocorrosion/utils-simd/ppv-lite86)
    Finished release [optimized] target(s) in 0.67s
     Running unittests src/lib.rs (/cryptocorrosion/target/release/deps/ppv_lite86-e90a0f30d548d0c3)

running 13 tests
test x86_64::sse2::test::test_bswap32_s2_vs_s3 ... ignored
test x86_64::sse2::test::test_bswap64_s2_vs_s3 ... ignored
test x86_64::sse2::test::test_lanes_u32x4 ... ignored
test x86_64::sse2::test::test_lanes_u64x2 ... ignored
test x86_64::sse2::test::test_shuffle32_s2_vs_s3 ... ignored
test x86_64::sse2::test::test_shuffle64_s2_vs_s3 ... ignored
test x86_64::sse2::test::test_vec2_u64x2_s2 ... ok
test x86_64::sse2::test::test_vec4_u32x4_s4 ... ignored
test x86_64::sse2::test::test_vec4_u64x2_s4 ... ignored
test x86_64::sse2::test::test_vec4_u32x4_s2 ... ok
test x86_64::test::test_zeroize_vec128_storage ... ok
test x86_64::test::test_zeroize_vec256_storage ... ok
test x86_64::test::test_zeroize_vec512_storage ... ok

test result: ok. 5 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests ppv-lite86

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
## aarch64 test results:
```
ppv-lite86 % cargo test --release --features zeroize_support
   Compiling ppv-lite86 v0.3.0 (/Zeroize_Support/cryptocorrosion/utils-simd/ppv-lite86)
    Finished release [optimized] target(s) in 0.44s
     Running unittests src/lib.rs (/Zeroize_Support/cryptocorrosion/target/release/deps/ppv_lite86-3f7b615e59afc0e0)

running 5 tests
test generic::test::test_bswap32 ... ok
test generic::test::test_zeroize_vec128_storage_generic ... ok
test generic::test::test_zeroize_vec512_storage_generic ... ok
test generic::test::test_zeroize_vec256_storage_generic ... ok
test generic::test_rotate_u128 ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests ppv-lite86

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

# Final notes
I did notice a directory in `utils-simd` called `crypto-simd`, which could be a suitable crate for this feature, but I don't know what the plans are for it.
If you have any suggestions for my code, please let me know if I need to make any changes, and feel free to make any changes as you see fit. Thank you for your time.