### PR TITLE
Use zerocopies derive feature rather than depending on zerocopy_derive

### DIFF
--- a/hashes/groestl/Cargo.toml
+++ b/hashes/groestl/Cargo.toml
@@ -15,8 +15,7 @@ rust-version = "1.61"
 block-buffer = "0.9"
 digest = "0.9"
 lazy_static = { version = "1.2", optional = true }
-zerocopy = { version = "0.7", features = ["simd"] }
-zerocopy-derive = "0.7"
+zerocopy = { version = "0.7", features = ["simd", "derive"] }
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/hashes/groestl/src/compressor.rs
+++ b/hashes/groestl/src/compressor.rs
@@ -2,7 +2,7 @@ use block_buffer::generic_array::typenum::{U128, U64};
 use block_buffer::generic_array::GenericArray;
 use core::arch::x86_64::*;
 use core::ops::BitXor;
-use zerocopy_derive::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 trait Map2 {
     type Output;

--- a/utils-simd/ppv-lite86/Cargo.toml
+++ b/utils-simd/ppv-lite86/Cargo.toml
@@ -11,8 +11,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.61"
 
 [dependencies]
-zerocopy = { version = "0.7", features = ["simd"] }
-zerocopy-derive = "0.7"
+zerocopy = { version = "0.7", features = ["simd", "derive"] }
 
 [badges]
 travis-ci = { repository = "cryptocorrosion/cryptocorrosion" }

--- a/utils-simd/ppv-lite86/src/generic.rs
+++ b/utils-simd/ppv-lite86/src/generic.rs
@@ -3,8 +3,7 @@
 use crate::soft::{x2, x4};
 use crate::types::*;
 use core::ops::*;
-use zerocopy::{AsBytes, FromBytes};
-use zerocopy_derive::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 #[repr(C)]
 #[derive(Clone, Copy, FromBytes, AsBytes, FromZeroes)]

--- a/utils-simd/ppv-lite86/src/soft.rs
+++ b/utils-simd/ppv-lite86/src/soft.rs
@@ -4,7 +4,7 @@ use crate::types::*;
 use crate::{vec128_storage, vec256_storage, vec512_storage};
 use core::marker::PhantomData;
 use core::ops::*;
-use zerocopy_derive::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 #[derive(Copy, Clone, Default, FromBytes, AsBytes, FromZeroes)]
 #[repr(transparent)]

--- a/utils-simd/ppv-lite86/src/x86_64/mod.rs
+++ b/utils-simd/ppv-lite86/src/x86_64/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::types::*;
 use core::arch::x86_64::{__m128i, __m256i};
-use zerocopy_derive::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 mod sse2;
 

--- a/utils-simd/ppv-lite86/src/x86_64/sse2.rs
+++ b/utils-simd/ppv-lite86/src/x86_64/sse2.rs
@@ -9,8 +9,7 @@ use core::marker::PhantomData;
 use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not,
 };
-use zerocopy::transmute;
-use zerocopy_derive::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{transmute, AsBytes, FromBytes, FromZeroes};
 
 macro_rules! impl_binop {
     ($vec:ident, $trait:ident, $fn:ident, $impl_fn:ident) => {
@@ -1385,8 +1384,7 @@ pub mod avx2 {
     use core::arch::x86_64::*;
     use core::marker::PhantomData;
     use core::ops::*;
-    use zerocopy::transmute;
-    use zerocopy_derive::{AsBytes, FromBytes, FromZeroes};
+    use zerocopy::{transmute, AsBytes, FromBytes, FromZeroes};
 
     #[derive(Copy, Clone, FromBytes, AsBytes, FromZeroes)]
     #[repr(transparent)]


### PR DESCRIPTION
This replaces the direct dependency on `zerocopy_derive` with the `derive` feature in `zerocopy`. Fixes #77.

Note that this does not remove `zerocopy_derive` from the build tree, because it is still depended on by `zerocopy`.

Regarding the tests you mentioned in in https://github.com/cryptocorrosion/cryptocorrosion/issues/77#issuecomment-2265403803, do you just want to make sure the GitHub test suite runs or do you want me to add a specific test?

If it's just about running the test suite, if it doesn't run on my MR feel free to just copy the branch from my fork to a new branch in the original repo and merge that once the tests have run.

If you want me to add a specific test, I could a add `cross test --no-fail-fast --target ${{ matrix.target }} -p ppv-lite86 --features "zerocopy/derive"` step to the CI, but I'm not sure that will test anything useful.