### PR TITLE
Update Blake hash to digest v0.10

### DIFF
--- a/hashes/blake/CHANGELOG.md
+++ b/hashes/blake/CHANGELOG.md
@@ -7,3 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.1]
 ### Changed
 - Update `ppv-lite86` dependency to fix support for non-x86 platforms.
+
+## 0.5.0
+### Changed
+- Update `digest` dependency to 0.10

--- a/hashes/blake/Cargo.toml
+++ b/hashes/blake/Cargo.toml
@@ -11,8 +11,8 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.61"
 
 [dependencies]
-block-buffer = "0.9"
 digest = "0.10"
+block-buffer = "0.10.4"
 simd = { package = "ppv-lite86", version = "0.2.16", optional = true }
 
 [features]

--- a/hashes/blake/Cargo.toml
+++ b/hashes/blake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blake-hash"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["The CryptoCorrosion Contributors"]
 license = "MIT/Apache-2.0"
 description = "BLAKE hash functions"
@@ -11,7 +11,7 @@ rust-version = "1.61"
 
 [dependencies]
 block-buffer = "0.9"
-digest = "0.9"
+digest = "0.10"
 simd = { package = "ppv-lite86", version = "0.2.16", optional = true }
 
 [features]
@@ -19,7 +19,7 @@ default = ["simd", "std"]
 std = []
 
 [dev-dependencies]
-digest = { version = "0.9", features = ["dev"] }
+digest = { version = "0.10", features = ["dev"] }
 
 [badges]
 travis-ci = { repository = "cryptocorrosion/cryptocorrosion" }

--- a/hashes/blake/Cargo.toml
+++ b/hashes/blake/Cargo.toml
@@ -2,6 +2,7 @@
 name = "blake-hash"
 version = "0.5.0"
 authors = ["The CryptoCorrosion Contributors"]
+edition = "2021"
 license = "MIT/Apache-2.0"
 description = "BLAKE hash functions"
 repository = "https://github.com/cryptocorrosion/cryptocorrosion"

--- a/hashes/blake/src/lib.rs
+++ b/hashes/blake/src/lib.rs
@@ -192,10 +192,6 @@ macro_rules! define_hasher {
             }
         }
 
-        impl digest::BlockInput for $name {
-            type BlockSize = $Bytes;
-        }
-
         impl digest::Update for $name {
             fn update(&mut self, data: impl AsRef<[u8]>) {
                 let compressor = &mut self.compressor;

--- a/hashes/blake/src/lib.rs
+++ b/hashes/blake/src/lib.rs
@@ -259,6 +259,8 @@ macro_rules! define_hasher {
                 *self = Self::default()
             }
         }
+
+        impl digest::HashMarker for $name { }
     };
 }
 

--- a/hashes/blake/src/lib.rs
+++ b/hashes/blake/src/lib.rs
@@ -12,7 +12,7 @@ pub extern crate simd;
 
 mod consts;
 
-use block_buffer::BlockBuffer;
+use block_buffer::{BlockBuffer, Eager};
 use core::convert::TryInto;
 use core::mem;
 use digest::generic_array::typenum::{PartialDiv, Unsigned, U2};
@@ -160,7 +160,7 @@ macro_rules! define_hasher {
         #[derive(Clone)]
         pub struct $name {
             compressor: $compressor,
-            buffer: BlockBuffer<$Bufsz>,
+            buffer: BlockBuffer<$Bufsz, Eager>,
             t: ($word, $word),
         }
 
@@ -196,14 +196,14 @@ macro_rules! define_hasher {
             fn update(&mut self, data: &[u8]) {
                 let compressor = &mut self.compressor;
                 let t = &mut self.t;
-                self.buffer.input_block(data.as_ref(), |block| {
+                self.buffer.digest_blocks(data.as_ref(), |block| {
                     Self::increase_count(t, (mem::size_of::<$word>() * 16) as $word);
-                    compressor.put_block(block, *t);
+                    compressor.put_block(&block[0], *t);
                 });
             }
         }
 
-        impl digest::OutputSizeUser for $name { 
+        impl digest::OutputSizeUser for $name {
             type OutputSize = $Bytes;
         }
 
@@ -213,7 +213,7 @@ macro_rules! define_hasher {
                 let mut buffer = self.buffer;
                 let mut t = self.t;
 
-                Self::increase_count(&mut t, buffer.position() as $word);
+                Self::increase_count(&mut t, buffer.get_pos() as $word);
 
                 let mut msglen = [0u8; $buf / 8];
                 msglen[..$buf / 16].copy_from_slice(&t.1.to_be_bytes());
@@ -224,7 +224,7 @@ macro_rules! define_hasher {
                 // low bit indicates full-length variant
                 let isfull = ($bits == 8 * mem::size_of::<[$word; 8]>()) as u8;
                 // high bit indicates fit with no padding
-                let exactfit = if buffer.position() + footerlen != $buf {
+                let exactfit = if buffer.get_pos() + footerlen != $buf {
                     0x00
                 } else {
                     0x80
@@ -232,28 +232,29 @@ macro_rules! define_hasher {
                 let magic = isfull | exactfit;
 
                 // if header won't fit in last data block, pad to the end and start a new one
-                let extra_block = buffer.position() + footerlen > $buf;
+                let extra_block = buffer.get_pos() + footerlen > $buf;
                 if extra_block {
-                    let pad = $buf - buffer.position();
-                    buffer.input_block(&PADDING[..pad], |block| compressor.put_block(block, t));
-                    debug_assert_eq!(buffer.position(), 0);
+                    let pad = $buf - buffer.get_pos();
+                    buffer
+                        .digest_blocks(&PADDING[..pad], |block| compressor.put_block(&block[0], t));
+                    debug_assert_eq!(buffer.get_pos(), 0);
                 }
 
                 // pad last block up to footer start point
-                if buffer.position() == 0 {
+                if buffer.get_pos() == 0 {
                     // don't xor t when the block is only padding
                     t = (0, 0);
                 }
                 // skip begin-padding byte if continuing padding
                 let x = extra_block as usize;
-                let (start, end) = (x, x + ($buf - footerlen - buffer.position()));
-                buffer.input_block(&PADDING[start..end], |_| unreachable!());
-                buffer.input_block(&[magic], |_| unreachable!());
-                buffer.input_block(&msglen, |block| compressor.put_block(block, t));
-                debug_assert_eq!(buffer.position(), 0);
+                let (start, end) = (x, x + ($buf - footerlen - buffer.get_pos()));
+                buffer.digest_blocks(&PADDING[start..end], |_| unreachable!());
+                buffer.digest_blocks(&[magic], |_| unreachable!());
+                buffer.digest_blocks(&msglen, |block| compressor.put_block(&block[0], t));
+                debug_assert_eq!(buffer.get_pos(), 0);
 
                 out.copy_from_slice(&compressor.finalize()[..$Bytes::to_usize()]);
-            }    
+            }
         }
 
         impl digest::FixedOutputReset for $name {
@@ -262,7 +263,7 @@ macro_rules! define_hasher {
                 let buffer = &mut self.buffer;
                 let mut t = self.t;
 
-                Self::increase_count(&mut t, buffer.position() as $word);
+                Self::increase_count(&mut t, buffer.get_pos() as $word);
 
                 let mut msglen = [0u8; $buf / 8];
                 msglen[..$buf / 16].copy_from_slice(&t.1.to_be_bytes());
@@ -273,7 +274,7 @@ macro_rules! define_hasher {
                 // low bit indicates full-length variant
                 let isfull = ($bits == 8 * mem::size_of::<[$word; 8]>()) as u8;
                 // high bit indicates fit with no padding
-                let exactfit = if buffer.position() + footerlen != $buf {
+                let exactfit = if buffer.get_pos() + footerlen != $buf {
                     0x00
                 } else {
                     0x80
@@ -281,25 +282,26 @@ macro_rules! define_hasher {
                 let magic = isfull | exactfit;
 
                 // if header won't fit in last data block, pad to the end and start a new one
-                let extra_block = buffer.position() + footerlen > $buf;
+                let extra_block = buffer.get_pos() + footerlen > $buf;
                 if extra_block {
-                    let pad = $buf - buffer.position();
-                    buffer.input_block(&PADDING[..pad], |block| compressor.put_block(block, t));
-                    debug_assert_eq!(buffer.position(), 0);
+                    let pad = $buf - buffer.get_pos();
+                    buffer
+                        .digest_blocks(&PADDING[..pad], |block| compressor.put_block(&block[0], t));
+                    debug_assert_eq!(buffer.get_pos(), 0);
                 }
 
                 // pad last block up to footer start point
-                if buffer.position() == 0 {
+                if buffer.get_pos() == 0 {
                     // don't xor t when the block is only padding
                     t = (0, 0);
                 }
                 // skip begin-padding byte if continuing padding
                 let x = extra_block as usize;
-                let (start, end) = (x, x + ($buf - footerlen - buffer.position()));
-                buffer.input_block(&PADDING[start..end], |_| unreachable!());
-                buffer.input_block(&[magic], |_| unreachable!());
-                buffer.input_block(&msglen, |block| compressor.put_block(block, t));
-                debug_assert_eq!(buffer.position(), 0);
+                let (start, end) = (x, x + ($buf - footerlen - buffer.get_pos()));
+                buffer.digest_blocks(&PADDING[start..end], |_| unreachable!());
+                buffer.digest_blocks(&[magic], |_| unreachable!());
+                buffer.digest_blocks(&msglen, |block| compressor.put_block(&block[0], t));
+                debug_assert_eq!(buffer.get_pos(), 0);
 
                 out.copy_from_slice(&compressor.finalize()[..$Bytes::to_usize()]);
             }
@@ -311,7 +313,7 @@ macro_rules! define_hasher {
             }
         }
 
-        impl digest::HashMarker for $name { }
+        impl digest::HashMarker for $name {}
     };
 }
 

--- a/hashes/blake/src/lib.rs
+++ b/hashes/blake/src/lib.rs
@@ -193,7 +193,7 @@ macro_rules! define_hasher {
         }
 
         impl digest::Update for $name {
-            fn update(&mut self, data: impl AsRef<[u8]>) {
+            fn update(&mut self, data: &[u8]) {
                 let compressor = &mut self.compressor;
                 let t = &mut self.t;
                 self.buffer.input_block(data.as_ref(), |block| {

--- a/hashes/blake/tests/lib.rs
+++ b/hashes/blake/tests/lib.rs
@@ -2,9 +2,14 @@ extern crate blake_hash;
 #[macro_use]
 extern crate digest;
 
-use digest::dev::digest_test;
+use digest::dev::{fixed_test, fixed_reset_test};
 
-new_test!(blake224, "blake224", blake_hash::Blake224, digest_test);
-new_test!(blake256, "blake256", blake_hash::Blake256, digest_test);
-//new_test!(blake384, "blake384", blake_hash::Blake384, digest_test);
-//new_test!(blake512, "blake512", blake_hash::Blake512, digest_test);
+new_test!(blake224, "blake224", blake_hash::Blake224, fixed_test);
+new_test!(blake256, "blake256", blake_hash::Blake256, fixed_test);
+//new_test!(blake384, "blake384", blake_hash::Blake384, fixed_test);
+//new_test!(blake512, "blake512", blake_hash::Blake512, fixed_test);
+
+new_test!(blake224_reset, "blake224", blake_hash::Blake224, fixed_reset_test);
+new_test!(blake256_reset, "blake256", blake_hash::Blake256, fixed_reset_test);
+//new_test!(blake384_reset, "blake384", blake_hash::Blake384, fixed_reset_test);
+//new_test!(blake512_reset, "blake512", blake_hash::Blake512, fixed_reset_test);


### PR DESCRIPTION
I would like to use this crate and combine it with other crates from [ark](https://arkworks.rs/). However the ark expected Traits implemented in v0.10 so I though of updating the dependencies in this package. 

Currently the tests are failing, as I need to update the `.blb`files (from blobby v0.1 -> v0.3), and I have struggle a bit. A bit of help or any cues to crate valid `.blb` files is much appreciated :)