### PR TITLE
Update zerocopy to 0.8

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "zerocopy_derive_union_into_bytes"]

--- a/hashes/groestl/Cargo.toml
+++ b/hashes/groestl/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.61"
 block-buffer = "0.9"
 digest = "0.9"
 lazy_static = { version = "1.2", optional = true }
-zerocopy = { version = "0.7", features = ["simd", "derive"] }
+zerocopy = { version = "0.8", features = ["simd", "derive"] }
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/hashes/groestl/src/compressor.rs
+++ b/hashes/groestl/src/compressor.rs
@@ -2,7 +2,7 @@ use block_buffer::generic_array::typenum::{U128, U64};
 use block_buffer::generic_array::GenericArray;
 use core::arch::x86_64::*;
 use core::ops::BitXor;
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, IntoBytes};
 
 trait Map2 {
     type Output;
@@ -12,7 +12,7 @@ trait Map2 {
         Self: Sized;
 }
 
-#[derive(Copy, Clone, FromBytes, AsBytes, FromZeroes)]
+#[derive(Copy, Clone, FromBytes, IntoBytes)]
 #[repr(C)]
 pub struct X4(__m128i, __m128i, __m128i, __m128i);
 

--- a/hashes/jh/Cargo.toml
+++ b/hashes/jh/Cargo.toml
@@ -16,7 +16,7 @@ block-buffer = { version = "0.9", features = ["block-padding"] }
 digest = "0.9"
 hex-literal = "0.3"
 simd = { package = "ppv-lite86", version = "0.2.6" }
-zerocopy = "0.7"
+zerocopy = "0.8"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/utils-simd/ppv-lite86/Cargo.toml
+++ b/utils-simd/ppv-lite86/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.61"
 
 [dependencies]
-zerocopy = { version = "0.7", features = ["simd", "derive"] }
+zerocopy = { version = "0.8", features = ["simd", "derive"] }
 
 [badges]
 travis-ci = { repository = "cryptocorrosion/cryptocorrosion" }

--- a/utils-simd/ppv-lite86/src/soft.rs
+++ b/utils-simd/ppv-lite86/src/soft.rs
@@ -4,9 +4,9 @@ use crate::types::*;
 use crate::{vec128_storage, vec256_storage, vec512_storage};
 use core::marker::PhantomData;
 use core::ops::*;
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, IntoBytes};
 
-#[derive(Copy, Clone, Default, FromBytes, AsBytes, FromZeroes)]
+#[derive(Copy, Clone, Default, FromBytes, IntoBytes)]
 #[repr(transparent)]
 #[allow(non_camel_case_types)]
 pub struct x2<W, G>(pub [W; 2], PhantomData<G>);
@@ -222,7 +222,7 @@ impl<W: Copy + LaneWords4, G: Copy> LaneWords4 for x2<W, G> {
     }
 }
 
-#[derive(Copy, Clone, Default, FromBytes, AsBytes, FromZeroes)]
+#[derive(Copy, Clone, Default, FromBytes, IntoBytes)]
 #[repr(transparent)]
 #[allow(non_camel_case_types)]
 pub struct x4<W>(pub [W; 4]);

--- a/utils-simd/ppv-lite86/src/x86_64/mod.rs
+++ b/utils-simd/ppv-lite86/src/x86_64/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::types::*;
 use core::arch::x86_64::{__m128i, __m256i};
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, IntoBytes};
 
 mod sse2;
 
@@ -107,7 +107,7 @@ pub type AVX2 = Avx2Machine<NoNI>;
 /// Converting into and out of this type should be essentially free, although it may be more
 /// aligned than a particular impl requires.
 #[allow(non_camel_case_types)]
-#[derive(Copy, Clone, FromBytes, AsBytes, FromZeroes)]
+#[derive(Copy, Clone, FromBytes, IntoBytes)]
 #[repr(C)]
 pub union vec128_storage {
     u32x4: [u32; 4],

--- a/utils-simd/ppv-lite86/src/x86_64/sse2.rs
+++ b/utils-simd/ppv-lite86/src/x86_64/sse2.rs
@@ -9,7 +9,7 @@ use core::marker::PhantomData;
 use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not,
 };
-use zerocopy::{transmute, AsBytes, FromBytes, FromZeroes};
+use zerocopy::{transmute, FromBytes, IntoBytes};
 
 macro_rules! impl_binop {
     ($vec:ident, $trait:ident, $fn:ident, $impl_fn:ident) => {
@@ -40,7 +40,7 @@ macro_rules! impl_binop_assign {
 macro_rules! def_vec {
     ($vec:ident, $word:ident) => {
         #[allow(non_camel_case_types)]
-        #[derive(Copy, Clone, FromBytes, AsBytes, FromZeroes)]
+        #[derive(Copy, Clone, FromBytes, IntoBytes)]
         #[repr(transparent)]
         pub struct $vec<S3, S4, NI> {
             x: __m128i,
@@ -1384,9 +1384,9 @@ pub mod avx2 {
     use core::arch::x86_64::*;
     use core::marker::PhantomData;
     use core::ops::*;
-    use zerocopy::{transmute, AsBytes, FromBytes, FromZeroes};
+    use zerocopy::{transmute, FromBytes, IntoBytes};
 
-    #[derive(Copy, Clone, FromBytes, AsBytes, FromZeroes)]
+    #[derive(Copy, Clone, FromBytes, IntoBytes)]
     #[repr(transparent)]
     pub struct u32x4x2_avx2<NI> {
         x: __m256i,


### PR DESCRIPTION
Mostly just removing `FromZeroes` as that's now implied by `FromBytes` and renaming `AsBytes` to `IntoBytes`. `--cfg zerocopy_derive_union_into_bytes` is now needed due to `utils-simd/ppv-lite86/src/x86_64/mod.rs` using `derive(IntoBytes)` on a union. 0.8 announcement and migration guide is at https://github.com/google/zerocopy/discussions/1680.

Closes https://github.com/cryptocorrosion/cryptocorrosion/issues/82.