### PR TITLE
Derive zerocopy traits via macro, remove custom derive dependency

### DIFF
--- a/hashes/groestl/Cargo.toml
+++ b/hashes/groestl/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.61"
 block-buffer = "0.9"
 digest = "0.9"
 lazy_static = { version = "1.2", optional = true }
-zerocopy = { version = "0.8", features = ["simd", "derive"] }
+zerocopy = { version = "0.8.23", features = ["simd"] }
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/hashes/groestl/src/compressor.rs
+++ b/hashes/groestl/src/compressor.rs
@@ -12,9 +12,11 @@ trait Map2 {
         Self: Sized;
 }
 
-#[derive(Copy, Clone, FromBytes, IntoBytes)]
-#[repr(C)]
-pub struct X4(__m128i, __m128i, __m128i, __m128i);
+zerocopy::cryptocorrosion_derive_traits! {
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    pub struct X4(__m128i, __m128i, __m128i, __m128i);
+}
 
 #[derive(Copy, Clone)]
 pub struct X8(

--- a/utils-simd/ppv-lite86/Cargo.toml
+++ b/utils-simd/ppv-lite86/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.61"
 
 [dependencies]
-zerocopy = { version = "0.8", features = ["simd", "derive"] }
+zerocopy = { version = "0.8.23", features = ["simd"] }
 
 [badges]
 travis-ci = { repository = "cryptocorrosion/cryptocorrosion" }

--- a/utils-simd/ppv-lite86/src/generic.rs
+++ b/utils-simd/ppv-lite86/src/generic.rs
@@ -3,14 +3,17 @@
 use crate::soft::{x2, x4};
 use crate::types::*;
 use core::ops::*;
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, IntoBytes};
 
-#[repr(C)]
-#[derive(Clone, Copy, FromBytes, AsBytes, FromZeroes)]
-pub union vec128_storage {
-    d: [u32; 4],
-    q: [u64; 2],
+zerocopy::cryptocorrosion_derive_traits! {
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub union vec128_storage {
+        d: [u32; 4],
+        q: [u64; 2],
+    }
 }
+
 impl From<[u32; 4]> for vec128_storage {
     #[inline(always)]
     fn from(d: [u32; 4]) -> Self {
@@ -453,15 +456,23 @@ impl Machine for GenericMachine {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, FromBytes, AsBytes, FromZeroes)]
-#[repr(transparent)]
-pub struct u32x4_generic([u32; 4]);
-#[derive(Copy, Clone, Debug, PartialEq, FromBytes, AsBytes, FromZeroes)]
-#[repr(transparent)]
-pub struct u64x2_generic([u64; 2]);
-#[derive(Copy, Clone, Debug, PartialEq, FromBytes, AsBytes, FromZeroes)]
-#[repr(transparent)]
-pub struct u128x1_generic([u128; 1]);
+zerocopy::cryptocorrosion_derive_traits! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub struct u32x4_generic([u32; 4]);
+}
+
+zerocopy::cryptocorrosion_derive_traits! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub struct u64x2_generic([u64; 2]);
+}
+
+zerocopy::cryptocorrosion_derive_traits! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub struct u128x1_generic([u128; 1]);
+}
 
 impl From<u32x4_generic> for vec128_storage {
     #[inline(always)]
@@ -565,12 +576,12 @@ impl BSwap for u128x1_generic {
 impl StoreBytes for u32x4_generic {
     #[inline(always)]
     unsafe fn unsafe_read_le(input: &[u8]) -> Self {
-        let x = u32x4_generic::read_from(input).unwrap();
+        let x = u32x4_generic::read_from_bytes(input).unwrap();
         dmap(x, |x| x.to_le())
     }
     #[inline(always)]
     unsafe fn unsafe_read_be(input: &[u8]) -> Self {
-        let x = u32x4_generic::read_from(input).unwrap();
+        let x = u32x4_generic::read_from_bytes(input).unwrap();
         dmap(x, |x| x.to_be())
     }
     #[inline(always)]
@@ -587,12 +598,12 @@ impl StoreBytes for u32x4_generic {
 impl StoreBytes for u64x2_generic {
     #[inline(always)]
     unsafe fn unsafe_read_le(input: &[u8]) -> Self {
-        let x = u64x2_generic::read_from(input).unwrap();
+        let x = u64x2_generic::read_from_bytes(input).unwrap();
         qmap(x, |x| x.to_le())
     }
     #[inline(always)]
     unsafe fn unsafe_read_be(input: &[u8]) -> Self {
-        let x = u64x2_generic::read_from(input).unwrap();
+        let x = u64x2_generic::read_from_bytes(input).unwrap();
         qmap(x, |x| x.to_be())
     }
     #[inline(always)]

--- a/utils-simd/ppv-lite86/src/soft.rs
+++ b/utils-simd/ppv-lite86/src/soft.rs
@@ -4,12 +4,14 @@ use crate::types::*;
 use crate::{vec128_storage, vec256_storage, vec512_storage};
 use core::marker::PhantomData;
 use core::ops::*;
-use zerocopy::{FromBytes, IntoBytes};
 
-#[derive(Copy, Clone, Default, FromBytes, IntoBytes)]
-#[repr(transparent)]
-#[allow(non_camel_case_types)]
-pub struct x2<W, G>(pub [W; 2], PhantomData<G>);
+zerocopy::cryptocorrosion_derive_traits! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Default)]
+    #[allow(non_camel_case_types)]
+    pub struct x2<W, G>(pub [W; 2], PhantomData<G>);
+}
+
 impl<W, G> x2<W, G> {
     #[inline(always)]
     pub fn new(xs: [W; 2]) -> Self {
@@ -222,10 +224,13 @@ impl<W: Copy + LaneWords4, G: Copy> LaneWords4 for x2<W, G> {
     }
 }
 
-#[derive(Copy, Clone, Default, FromBytes, IntoBytes)]
-#[repr(transparent)]
-#[allow(non_camel_case_types)]
-pub struct x4<W>(pub [W; 4]);
+zerocopy::cryptocorrosion_derive_traits! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Default)]
+    #[allow(non_camel_case_types)]
+    pub struct x4<W>(pub [W; 4]);
+}
+
 impl<W> x4<W> {
     #[inline(always)]
     pub fn new(xs: [W; 4]) -> Self {

--- a/utils-simd/ppv-lite86/src/x86_64/mod.rs
+++ b/utils-simd/ppv-lite86/src/x86_64/mod.rs
@@ -2,7 +2,6 @@
 
 use crate::types::*;
 use core::arch::x86_64::{__m128i, __m256i};
-use zerocopy::{FromBytes, IntoBytes};
 
 mod sse2;
 
@@ -103,18 +102,21 @@ pub type SSE41 = SseMachine<YesS3, YesS4, NoNI>;
 pub type AVX = SseMachine<YesS3, YesS4, NoNI>;
 pub type AVX2 = Avx2Machine<NoNI>;
 
-/// Generic wrapper for unparameterized storage of any of the possible impls.
-/// Converting into and out of this type should be essentially free, although it may be more
-/// aligned than a particular impl requires.
-#[allow(non_camel_case_types)]
-#[derive(Copy, Clone, FromBytes, IntoBytes)]
-#[repr(C)]
-pub union vec128_storage {
-    u32x4: [u32; 4],
-    u64x2: [u64; 2],
-    u128x1: [u128; 1],
-    sse2: __m128i,
+zerocopy::cryptocorrosion_derive_traits! {
+    #[repr(C)]
+    /// Generic wrapper for unparameterized storage of any of the possible impls.
+    /// Converting into and out of this type should be essentially free, although it may be more
+    /// aligned than a particular impl requires.
+    #[allow(non_camel_case_types)]
+    #[derive(Copy, Clone)]
+    pub union vec128_storage {
+        u32x4: [u32; 4],
+        u64x2: [u64; 2],
+        u128x1: [u128; 1],
+        sse2: __m128i,
+    }
 }
+
 impl Store<vec128_storage> for vec128_storage {
     #[inline(always)]
     unsafe fn unpack(p: vec128_storage) -> Self {

--- a/utils-simd/ppv-lite86/src/x86_64/sse2.rs
+++ b/utils-simd/ppv-lite86/src/x86_64/sse2.rs
@@ -9,7 +9,7 @@ use core::marker::PhantomData;
 use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not,
 };
-use zerocopy::{transmute, FromBytes, IntoBytes};
+use zerocopy::transmute;
 
 macro_rules! impl_binop {
     ($vec:ident, $trait:ident, $fn:ident, $impl_fn:ident) => {
@@ -39,14 +39,16 @@ macro_rules! impl_binop_assign {
 
 macro_rules! def_vec {
     ($vec:ident, $word:ident) => {
-        #[allow(non_camel_case_types)]
-        #[derive(Copy, Clone, FromBytes, IntoBytes)]
-        #[repr(transparent)]
-        pub struct $vec<S3, S4, NI> {
-            x: __m128i,
-            s3: PhantomData<S3>,
-            s4: PhantomData<S4>,
-            ni: PhantomData<NI>,
+        zerocopy::cryptocorrosion_derive_traits! {
+            #[repr(transparent)]
+            #[allow(non_camel_case_types)]
+            #[derive(Copy, Clone)]
+            pub struct $vec<S3, S4, NI> {
+                x: __m128i,
+                s3: PhantomData<S3>,
+                s4: PhantomData<S4>,
+                ni: PhantomData<NI>,
+            }
         }
 
         impl<S3, S4, NI> Store<vec128_storage> for $vec<S3, S4, NI> {
@@ -1384,13 +1386,15 @@ pub mod avx2 {
     use core::arch::x86_64::*;
     use core::marker::PhantomData;
     use core::ops::*;
-    use zerocopy::{transmute, FromBytes, IntoBytes};
+    use zerocopy::transmute;
 
-    #[derive(Copy, Clone, FromBytes, IntoBytes)]
-    #[repr(transparent)]
-    pub struct u32x4x2_avx2<NI> {
-        x: __m256i,
-        ni: PhantomData<NI>,
+    zerocopy::cryptocorrosion_derive_traits! {
+        #[repr(transparent)]
+        #[derive(Copy, Clone)]
+        pub struct u32x4x2_avx2<NI> {
+            x: __m256i,
+            ni: PhantomData<NI>,
+        }
     }
 
     impl<NI> u32x4x2_avx2<NI> {


### PR DESCRIPTION
This commit disables zerocopy's `derive` feature, replacing uses of custom derives with uses of a newly-introduced [1] `macro_rules!` macro which is specifically added to support the ppv-lite86 and groestl-aesni crates. This allows us to no longer take a dependency on any proc macro derive, and thus to no longer take dependencies on expensive-to-compile crates like syn.

[1] https://github.com/google/zerocopy/pull/2418